### PR TITLE
Circlici configure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
     steps:
       - checkout
       - run: cp -r frontend/package.json ~/market/frontend/
+      - run: cp -r frontend/src ~/market/frontend/
       - run:
           name: Install deps
           command: yarn install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,11 @@ jobs:
     working_directory: ~/market/frontend
     steps:
       - checkout
+      - run: cp -r frontend/package.json ~/market/frontend/
       - run:
           name: Install deps
           command: yarn install
+      - run: ls -la ~/market/frontend
       - run:
           name: Run tests
           command: yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2.1
+
+jobs:
+  build-and-test:
+    docker:
+      - image: cimg/node:16.18
+    working_directory: ~/market/frontend
+    steps:
+      - checkout
+      - run:
+          name: Install deps
+          command: yarn install
+      - run:
+          name: Run tests
+          command: yarn test
+
+workflows:
+  build-and-test:
+    jobs:
+      - build-and-test


### PR DESCRIPTION
# Description

Configuring CircleCI. Copying local package.json and src directory to ~/market/frontend/ and successfully running the CircleCI workflow.